### PR TITLE
set up basic routing with placeholder pages

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-router-dom": "^7.13.1",
         "recoil": "^0.7.7"
       },
       "devDependencies": {
@@ -1352,6 +1353,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2923,6 +2937,44 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
+      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
+      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -3101,6 +3153,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-router-dom": "^7.13.1",
     "recoil": "^0.7.7"
   },
   "devDependencies": {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,7 +1,18 @@
+import { Routes, Route, Link } from 'react-router-dom'
+import Home from './pages/Home'
+import Courses from './pages/Courses'
+
 function App() {
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-950">
-      <p className="text-blue-500 text-2xl font-bold">Tailwind is working!</p>
+    <div className="min-h-screen bg-gray-950">
+      <nav className="flex gap-6 p-4 border-b border-gray-800">
+        <Link to="/" className="text-blue-400 hover:text-blue-300">Home</Link>
+        <Link to="/courses" className="text-blue-400 hover:text-blue-300">Courses</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/courses" element={<Courses />} />
+      </Routes>
     </div>
   )
 }

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,13 +1,16 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { RecoilRoot } from 'recoil'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <RecoilRoot>
-      <App />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
     </RecoilRoot>
   </StrictMode>,
 )

--- a/client/src/pages/Courses.jsx
+++ b/client/src/pages/Courses.jsx
@@ -1,0 +1,7 @@
+export default function Courses() {
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <h1 className="text-3xl font-bold text-white">Courses</h1>
+    </div>
+  )
+}

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <h1 className="text-3xl font-bold text-white">Home</h1>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Added `react-router-dom` to the client
- Wired `BrowserRouter` at app entry (wraps inside `RecoilRoot`)
- Added two placeholder routes:
  - `/` (Home)
  - `/courses` (Courses)
- Added minimal nav links between the two routes

## Validation
- `npm run build` passes with no errors
- Routes and nav links verified in browser

Closes #10 