### PR TITLE
add coming soon pages for community channels and announcements

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,6 +1,9 @@
 import { Routes, Route } from 'react-router-dom'
 import Home from './pages/Home'
 import Courses from './pages/Courses'
+import Community from './pages/Community'
+import Channels from './pages/Channels'
+import Announcements from './pages/Announcements'
 import AppShell from './components/AppShell'
 
 function App() {
@@ -9,6 +12,9 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/courses" element={<Courses />} />
+        <Route path="/community" element={<Community />} />
+        <Route path="/channels" element={<Channels />} />
+        <Route path="/announcements" element={<Announcements />} />
       </Routes>
     </AppShell>
   )

--- a/client/src/components/Sidebar.jsx
+++ b/client/src/components/Sidebar.jsx
@@ -1,11 +1,25 @@
+import { Link } from 'react-router-dom'
+
 export default function Sidebar() {
   return (
     <aside className="w-56 border-r border-gray-800 bg-gray-900/40 p-4 hidden sm:block">
       <p className="text-xs uppercase tracking-wide text-gray-400 mb-3">Sidebar</p>
       <ul className="space-y-2 text-sm text-gray-200">
-        <li>Dashboard (placeholder)</li>
-        <li>My Courses (placeholder)</li>
-        <li>Community (placeholder)</li>
+        <li>
+          <Link to="/" className="hover:text-blue-300">Dashboard</Link>
+        </li>
+        <li>
+          <Link to="/courses" className="hover:text-blue-300">My Courses</Link>
+        </li>
+        <li>
+          <Link to="/community" className="hover:text-blue-300">Community</Link>
+        </li>
+        <li>
+          <Link to="/channels" className="hover:text-blue-300">Channels</Link>
+        </li>
+        <li>
+          <Link to="/announcements" className="hover:text-blue-300">Announcements</Link>
+        </li>
       </ul>
     </aside>
   )

--- a/client/src/components/TopNav.jsx
+++ b/client/src/components/TopNav.jsx
@@ -8,6 +8,9 @@ export default function TopNav() {
         <nav className="flex items-center gap-5 text-sm">
           <Link to="/" className="text-blue-400 hover:text-blue-300">Home</Link>
           <Link to="/courses" className="text-blue-400 hover:text-blue-300">Courses</Link>
+          <Link to="/community" className="text-blue-400 hover:text-blue-300">Community</Link>
+          <Link to="/channels" className="text-blue-400 hover:text-blue-300">Channels</Link>
+          <Link to="/announcements" className="text-blue-400 hover:text-blue-300">Announcements</Link>
         </nav>
       </div>
     </header>

--- a/client/src/pages/Announcements.jsx
+++ b/client/src/pages/Announcements.jsx
@@ -1,0 +1,15 @@
+export default function Announcements() {
+  return (
+    <div className="flex min-h-full items-center justify-center px-6 py-16">
+      <div className="max-w-xl text-center">
+        <p className="mb-3 text-sm font-medium uppercase tracking-[0.2em] text-blue-400">
+          Coming Soon
+        </p>
+        <h1 className="mb-4 text-3xl font-bold text-white">Announcements</h1>
+        <p className="text-gray-300">
+          Announcement features will be available once backend support is ready.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/client/src/pages/Channels.jsx
+++ b/client/src/pages/Channels.jsx
@@ -1,0 +1,15 @@
+export default function Channels() {
+  return (
+    <div className="flex min-h-full items-center justify-center px-6 py-16">
+      <div className="max-w-xl text-center">
+        <p className="mb-3 text-sm font-medium uppercase tracking-[0.2em] text-blue-400">
+          Coming Soon
+        </p>
+        <h1 className="mb-4 text-3xl font-bold text-white">Channels</h1>
+        <p className="text-gray-300">
+          Channel features will be available once backend support is ready.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/client/src/pages/Community.jsx
+++ b/client/src/pages/Community.jsx
@@ -1,0 +1,15 @@
+export default function Community() {
+  return (
+    <div className="flex min-h-full items-center justify-center px-6 py-16">
+      <div className="max-w-xl text-center">
+        <p className="mb-3 text-sm font-medium uppercase tracking-[0.2em] text-blue-400">
+          Coming Soon
+        </p>
+        <h1 className="mb-4 text-3xl font-bold text-white">Community</h1>
+        <p className="text-gray-300">
+          Community features will be available once backend support is ready.
+        </p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Added placeholder pages for Community, Channels, and Announcements
- Added routes for `/community`, `/channels`, and `/announcements`
- Added navigation links to access new placeholder pages
- Marked all three pages as “Coming Soon”
- Kept existing routes unchanged

## Validation
- npm run build passes
- Navigation works for all placeholder routes

Closes #20 