### PR TITLE
feat(frontend): add user signin page with JWT storage

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -5,6 +5,7 @@ import Community from './pages/Community'
 import Channels from './pages/Channels'
 import Announcements from './pages/Announcements'
 import Signup from './pages/Signup'
+import Signin from './pages/Signin'
 import AppShell from './components/AppShell'
 
 function App() {
@@ -17,6 +18,7 @@ function App() {
         <Route path="/channels" element={<Channels />} />
         <Route path="/announcements" element={<Announcements />} />
         <Route path="/signup" element={<Signup />} />
+        <Route path="/signin" element={<Signin />} />
       </Routes>
     </AppShell>
   )

--- a/client/src/components/TopNav.jsx
+++ b/client/src/components/TopNav.jsx
@@ -10,6 +10,7 @@ export default function TopNav() {
           <Link to="/courses" className="text-blue-400 hover:text-blue-300">Courses</Link>
           <Link to="/community" className="text-blue-400 hover:text-blue-300">Community</Link>
           <Link to="/signup" className="ml-4 rounded-lg bg-blue-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-400">Sign up</Link>
+          <Link to="/signin" className="rounded-lg border border-gray-700 px-3 py-1.5 text-sm font-medium text-gray-300 hover:text-white">Sign in</Link>
           <Link to="/channels" className="text-blue-400 hover:text-blue-300">Channels</Link>
           <Link to="/announcements" className="text-blue-400 hover:text-blue-300">Announcements</Link>
         </nav>

--- a/client/src/pages/Signin.jsx
+++ b/client/src/pages/Signin.jsx
@@ -1,0 +1,94 @@
+import { useState } from 'react'
+import { useNavigate, Link } from 'react-router-dom'
+import { signin } from '../services/auth'
+
+export default function Signin() {
+  const navigate = useNavigate()
+  const [form, setForm] = useState({ email: '', password: '' })
+  const [error, setError] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+
+  function handleChange(e) {
+    setForm((prev) => ({ ...prev, [e.target.name]: e.target.value }))
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    setError('')
+    setIsLoading(true)
+
+    try {
+      const data = await signin(form)
+      localStorage.setItem('token', data.token)
+      navigate('/')
+    } catch (err) {
+      setError(err.response?.data?.message || 'Sign in failed. Please try again.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-full items-center justify-center px-6 py-16">
+      <div className="w-full max-w-md space-y-8">
+        <div className="text-center">
+          <h1 className="text-3xl font-bold text-white">Sign in to your account</h1>
+          <p className="mt-2 text-sm text-gray-400">
+            Don't have an account?{' '}
+            <Link to="/signup" className="text-blue-400 hover:text-blue-300">
+              Sign up
+            </Link>
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-gray-300 mb-1.5">
+              Email address
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              required
+              value={form.email}
+              onChange={handleChange}
+              className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2.5 text-sm text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+              placeholder="john@example.com"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-gray-300 mb-1.5">
+              Password
+            </label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              required
+              value={form.password}
+              onChange={handleChange}
+              className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2.5 text-sm text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+              placeholder="Your password"
+            />
+          </div>
+
+          {error && (
+            <p className="rounded-lg bg-red-500/10 border border-red-500/30 px-4 py-3 text-sm text-red-300">
+              {error}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="w-full rounded-lg bg-blue-500 px-4 py-2.5 text-sm font-semibold text-white hover:bg-blue-400 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isLoading ? 'Signing in...' : 'Sign in'}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/client/src/services/auth.js
+++ b/client/src/services/auth.js
@@ -4,3 +4,8 @@ export async function signup({ email, password, firstName, lastName }) {
   const response = await api.post('/user/signup', { email, password, firstName, lastName })
   return response.data
 }
+
+export async function signin({ email, password }) {
+  const response = await api.post('/user/signin', { email, password })
+  return response.data
+}


### PR DESCRIPTION
## Summary
- Added Signin page with email and password form
- Added `signin()` in `src/services/auth.js`
- Stores returned JWT in localStorage on success
- Redirects to home on success
- Added `/signin` route and Sign in link in top nav


Closes #28 