### PR TITLE
feat(frontend): add axios auth interceptor for bearer token

### DIFF
--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -4,4 +4,14 @@ const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
 })
 
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token')
+
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`
+  }
+
+  return config
+})
+
 export default api


### PR DESCRIPTION
## Summary
- Added Axios request interceptor in shared API client
- Automatically attaches `Authorization: Bearer <token>` when token exists
- Keeps requests unchanged when user is logged out
- No UI or route changes



Closes #34 