### PR TITLE
feat: add enroll action for course cards

### DIFF
--- a/client/src/pages/Courses.jsx
+++ b/client/src/pages/Courses.jsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react'
-import { getCoursePreview } from '../services/course'
+import { enrollInCourse, getCoursePreview } from '../services/course'
 
 export default function Courses() {
   const [courses, setCourses] = useState([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState('')
+  const [enrollingCourseId, setEnrollingCourseId] = useState('')
+  const [courseFeedback, setCourseFeedback] = useState({})
 
   useEffect(() => {
     let isMounted = true
@@ -38,6 +40,35 @@ export default function Courses() {
       isMounted = false
     }
   }, [])
+
+  async function handleEnroll(courseId) {
+    setEnrollingCourseId(courseId)
+    setCourseFeedback((prev) => ({
+      ...prev,
+      [courseId]: null,
+    }))
+
+    try {
+      const data = await enrollInCourse(courseId)
+      setCourseFeedback((prev) => ({
+        ...prev,
+        [courseId]: {
+          type: data.paymentRequired ? 'info' : 'success',
+          message: data.message || 'Enrollment request completed.',
+        },
+      }))
+    } catch (err) {
+      setCourseFeedback((prev) => ({
+        ...prev,
+        [courseId]: {
+          type: 'error',
+          message: err.response?.data?.message || 'Unable to enroll right now.',
+        },
+      }))
+    } finally {
+      setEnrollingCourseId('')
+    }
+  }
 
   if (isLoading) {
     return (
@@ -103,6 +134,29 @@ export default function Courses() {
               <p className="text-sm font-medium text-blue-300">
                 {course.isFree ? 'Free' : `Price: $${course.price}`}
               </p>
+
+              <button
+                type="button"
+                onClick={() => handleEnroll(course._id)}
+                disabled={enrollingCourseId === course._id}
+                className="w-full rounded-lg bg-blue-500 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-400 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {enrollingCourseId === course._id ? 'Enrolling...' : 'Enroll'}
+              </button>
+
+              {courseFeedback[course._id] && (
+                <p
+                  className={`text-sm ${
+                    courseFeedback[course._id].type === 'error'
+                      ? 'text-red-300'
+                      : courseFeedback[course._id].type === 'info'
+                        ? 'text-amber-300'
+                        : 'text-emerald-300'
+                  }`}
+                >
+                  {courseFeedback[course._id].message}
+                </p>
+              )}
             </div>
           </article>
         ))}

--- a/client/src/services/course.js
+++ b/client/src/services/course.js
@@ -4,3 +4,8 @@ export async function getCoursePreview() {
   const response = await api.get('/course/preview')
   return response.data.courses ?? []
 }
+
+export async function enrollInCourse(courseId) {
+  const response = await api.post('/user/course/enroll', { courseId })
+  return response.data
+}

--- a/middleware/userAuth.js
+++ b/middleware/userAuth.js
@@ -4,13 +4,17 @@ const USER_JWT_SECRET = process.env.USER_JWT_SECRET;
 
 function userAuth(req, res, next){
 
-    const token = req.headers.authorization;
+    const authHeader = req.headers.authorization;
 
-    if(!token){
+    if(!authHeader){
         return res.status(401).json({
             message: "Token missing"
         });
     }
+
+    const token = authHeader.startsWith("Bearer ")
+        ? authHeader.slice(7)
+        : authHeader;
 
     try{
 


### PR DESCRIPTION
## Summary
- Added enroll API call for `POST /user/course/enroll`
- Added Enroll button to each course card
- Sends `{ courseId }` payload for selected course
- Added loading and success/error feedback for enroll actions
- Reused existing auth interceptor for bearer token

## Validation
- npm run build passes
- CI checks pass
- Enroll request succeeds for authenticated users

Closes #36 