### PR TITLE
feat(auth): split learner and instructor experiences

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,13 +1,19 @@
-import { Routes, Route } from 'react-router-dom'
+import { Routes, Route, Navigate } from 'react-router-dom'
 import Home from './pages/Home'
 import Courses from './pages/Courses'
 import Community from './pages/Community'
 import Channels from './pages/Channels'
 import Announcements from './pages/Announcements'
 import MyCourses from './pages/MyCourses'
+import LearnerSignup from './pages/LearnerSignup'
 import Signup from './pages/Signup'
 import Signin from './pages/Signin'
+import AdminSignup from './pages/AdminSignup'
+import AdminCourses from './pages/AdminCourses'
+import AdminCreateCourse from './pages/AdminCreateCourse'
+import AdminEditCourse from './pages/AdminEditCourse'
 import AppShell from './components/AppShell'
+import AdminProtectedRoute from './components/AdminProtectedRoute'
 import ProtectedRoute from './components/ProtectedRoute'
 
 function App() {
@@ -35,7 +41,37 @@ function App() {
         <Route path="/channels" element={<Channels />} />
         <Route path="/announcements" element={<Announcements />} />
         <Route path="/signup" element={<Signup />} />
+        <Route path="/signup/learner" element={<LearnerSignup />} />
+        <Route path="/signup/instructor" element={<AdminSignup />} />
         <Route path="/signin" element={<Signin />} />
+        <Route path="/admin" element={<Navigate to="/instructor/courses" replace />} />
+        <Route path="/admin/signup" element={<Navigate to="/signup/instructor" replace />} />
+        <Route path="/admin/signin" element={<Navigate to="/signin" replace />} />
+        <Route path="/instructor" element={<Navigate to="/instructor/courses" replace />} />
+        <Route
+          path="/instructor/courses"
+          element={
+            <AdminProtectedRoute>
+              <AdminCourses />
+            </AdminProtectedRoute>
+          }
+        />
+        <Route
+          path="/instructor/courses/new"
+          element={
+            <AdminProtectedRoute>
+              <AdminCreateCourse />
+            </AdminProtectedRoute>
+          }
+        />
+        <Route
+          path="/instructor/courses/:courseId/edit"
+          element={
+            <AdminProtectedRoute>
+              <AdminEditCourse />
+            </AdminProtectedRoute>
+          }
+        />
       </Routes>
     </AppShell>
   )

--- a/client/src/components/AdminCourseForm.jsx
+++ b/client/src/components/AdminCourseForm.jsx
@@ -1,0 +1,152 @@
+import { useEffect, useState } from 'react'
+
+const defaultValues = {
+  title: '',
+  description: '',
+  imageUrl: '',
+  price: '0',
+  isFree: true,
+}
+
+export default function AdminCourseForm({
+  initialValues = defaultValues,
+  onSubmit,
+  submitLabel,
+  isSubmitting,
+  error,
+}) {
+  const [form, setForm] = useState(initialValues)
+  const [clientError, setClientError] = useState('')
+
+  useEffect(() => {
+    setForm({ ...defaultValues, ...initialValues })
+  }, [initialValues])
+
+  function handleChange(event) {
+    const { name, value, type, checked } = event.target
+    setForm((prev) => ({
+      ...prev,
+      [name]: type === 'checkbox' ? checked : value,
+      ...(name === 'isFree' && checked ? { price: '0' } : {}),
+    }))
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault()
+    setClientError('')
+
+    const price = form.isFree ? 0 : Number(form.price)
+
+    if (!form.isFree && (!Number.isFinite(price) || price <= 0)) {
+      setClientError('Paid courses must have a price greater than 0.')
+      return
+    }
+
+    await onSubmit({
+      title: form.title.trim(),
+      description: form.description.trim(),
+      imageUrl: form.imageUrl.trim(),
+      isFree: form.isFree,
+      price,
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div>
+        <label htmlFor="title" className="mb-1.5 block text-sm font-medium text-gray-300">
+          Course title
+        </label>
+        <input
+          id="title"
+          name="title"
+          type="text"
+          minLength={3}
+          required
+          value={form.title}
+          onChange={handleChange}
+          className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2.5 text-sm text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+          placeholder="Design systems for product teams"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="description" className="mb-1.5 block text-sm font-medium text-gray-300">
+          Description
+        </label>
+        <textarea
+          id="description"
+          name="description"
+          minLength={10}
+          required
+          value={form.description}
+          onChange={handleChange}
+          rows={5}
+          className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-3 text-sm text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+          placeholder="Explain what learners will get from this course."
+        />
+      </div>
+
+      <div>
+        <label htmlFor="imageUrl" className="mb-1.5 block text-sm font-medium text-gray-300">
+          Cover image URL
+        </label>
+        <input
+          id="imageUrl"
+          name="imageUrl"
+          type="url"
+          required
+          value={form.imageUrl}
+          onChange={handleChange}
+          className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2.5 text-sm text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+          placeholder="https://images.example.com/course-cover.jpg"
+        />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-[1fr,220px]">
+        <label className="flex items-center gap-3 rounded-xl border border-gray-800 bg-gray-900/60 px-4 py-3 text-sm text-gray-200">
+          <input
+            name="isFree"
+            type="checkbox"
+            checked={form.isFree}
+            onChange={handleChange}
+            className="h-4 w-4 rounded border-gray-600 bg-gray-900 text-blue-500 focus:ring-blue-500"
+          />
+          This is a free course
+        </label>
+
+        <div>
+          <label htmlFor="price" className="mb-1.5 block text-sm font-medium text-gray-300">
+            Price
+          </label>
+          <input
+            id="price"
+            name="price"
+            type="number"
+            min="0"
+            step="0.01"
+            disabled={form.isFree}
+            value={form.isFree ? '0' : form.price}
+            onChange={handleChange}
+            className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2.5 text-sm text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+            placeholder="49"
+          />
+        </div>
+      </div>
+
+      {(clientError || error) && (
+        <p className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+          {clientError || error}
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={isSubmitting}
+        className="rounded-lg bg-blue-500 px-5 py-2.5 text-sm font-semibold text-white hover:bg-blue-400 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {isSubmitting ? 'Saving...' : submitLabel}
+      </button>
+    </form>
+  )
+}

--- a/client/src/components/AdminProtectedRoute.jsx
+++ b/client/src/components/AdminProtectedRoute.jsx
@@ -1,0 +1,14 @@
+import { Navigate, useLocation } from 'react-router-dom'
+import { useAtomValue } from 'jotai'
+import { adminAuthAtom } from '../state/adminAuthAtom'
+
+export default function AdminProtectedRoute({ children }) {
+  const adminAuth = useAtomValue(adminAuthAtom)
+  const location = useLocation()
+
+  if (!adminAuth.isLoggedIn) {
+    return <Navigate to="/signin" replace state={{ from: location.pathname }} />
+  }
+
+  return children
+}

--- a/client/src/components/AppShell.jsx
+++ b/client/src/components/AppShell.jsx
@@ -1,14 +1,18 @@
+import { useLocation } from 'react-router-dom'
 import TopNav from './TopNav'
 import Sidebar from './Sidebar'
 import SessionBootstrap from './SessionBootstrap'
 
 export default function AppShell({ children }) {
+  const location = useLocation()
+  const hideSidebar = ['/signin', '/signup', '/signup/learner', '/signup/instructor'].includes(location.pathname)
+
   return (
     <div className="min-h-screen bg-gray-950 text-white">
       <SessionBootstrap />
       <TopNav />
       <div className="flex min-h-[calc(100vh-56px)]">
-        <Sidebar />
+        {!hideSidebar && <Sidebar />}
         <main className="flex-1">{children}</main>
       </div>
     </div>

--- a/client/src/components/Sidebar.jsx
+++ b/client/src/components/Sidebar.jsx
@@ -1,26 +1,59 @@
-import { Link } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
+import { useAtomValue } from 'jotai'
+import { adminAuthAtom } from '../state/adminAuthAtom'
 
 export default function Sidebar() {
+  const location = useLocation()
+  const instructorAuth = useAtomValue(adminAuthAtom)
+  const isInstructorRoute = location.pathname.startsWith('/instructor') || location.pathname.startsWith('/admin')
+
   return (
     <aside className="w-56 border-r border-gray-800 bg-gray-900/40 p-4 hidden sm:block">
-      <p className="text-xs uppercase tracking-wide text-gray-400 mb-3">Sidebar</p>
-      <ul className="space-y-2 text-sm text-gray-200">
-        <li>
-          <Link to="/" className="hover:text-blue-300">Dashboard</Link>
-        </li>
-        <li>
-          <Link to="/my-courses" className="hover:text-blue-300">My Courses</Link>
-        </li>
-        <li>
-          <Link to="/community" className="hover:text-blue-300">Community</Link>
-        </li>
-        <li>
-          <Link to="/channels" className="hover:text-blue-300">Channels</Link>
-        </li>
-        <li>
-          <Link to="/announcements" className="hover:text-blue-300">Announcements</Link>
-        </li>
-      </ul>
+      {isInstructorRoute ? (
+        <>
+          <p className="mb-3 text-xs uppercase tracking-wide text-gray-400">Instructor</p>
+          <ul className="space-y-2 text-sm text-gray-200">
+            <li>
+              <Link to="/instructor/courses" className="hover:text-blue-300">Course Catalog</Link>
+            </li>
+            {instructorAuth.isLoggedIn ? (
+              <li>
+                <Link to="/instructor/courses/new" className="hover:text-blue-300">Create Course</Link>
+              </li>
+            ) : (
+              <>
+                <li>
+                  <Link to="/signin" className="hover:text-blue-300">Sign In</Link>
+                </li>
+                <li>
+                  <Link to="/signup" className="hover:text-blue-300">Choose Account Type</Link>
+                </li>
+              </>
+            )}
+          </ul>
+        </>
+      ) : (
+        <>
+          <p className="text-xs uppercase tracking-wide text-gray-400 mb-3">Sidebar</p>
+          <ul className="space-y-2 text-sm text-gray-200">
+            <li>
+              <Link to="/" className="hover:text-blue-300">Dashboard</Link>
+            </li>
+            <li>
+              <Link to="/my-courses" className="hover:text-blue-300">My Courses</Link>
+            </li>
+            <li>
+              <Link to="/community" className="hover:text-blue-300">Community</Link>
+            </li>
+            <li>
+              <Link to="/channels" className="hover:text-blue-300">Channels</Link>
+            </li>
+            <li>
+              <Link to="/announcements" className="hover:text-blue-300">Announcements</Link>
+            </li>
+          </ul>
+        </>
+      )}
     </aside>
   )
 }

--- a/client/src/components/TopNav.jsx
+++ b/client/src/components/TopNav.jsx
@@ -1,51 +1,100 @@
-import { Link, useNavigate } from 'react-router-dom'
-import { useAtom } from 'jotai'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
+import { useAtom, useAtomValue } from 'jotai'
+import { adminAuthAtom } from '../state/adminAuthAtom'
 import { authAtom } from '../state/authAtom'
 import { enrolledCoursesAtom } from '../state/enrolledCoursesAtom'
 import { profileAtom } from '../state/profileAtom'
-import { clearLearnerSession } from '../state/sessionActions'
+import { clearAdminSession, clearLearnerSession } from '../state/sessionActions'
 
 export default function TopNav() {
+  const location = useLocation()
   const navigate = useNavigate()
   const [auth] = useAtom(authAtom)
   const [profile] = useAtom(profileAtom)
   const [, setEnrolledCourses] = useAtom(enrolledCoursesAtom)
+  const instructorAuth = useAtomValue(adminAuthAtom)
+  const isInstructorRoute = location.pathname.startsWith('/instructor') || location.pathname.startsWith('/admin')
 
-  function handleSignout() {
+  function handleLearnerSignout() {
     clearLearnerSession()
     setEnrolledCourses([])
     navigate('/')
+  }
+
+  function handleInstructorSignout() {
+    clearAdminSession()
+    navigate('/signin')
   }
 
   return (
     <header className="h-14 border-b border-gray-800 bg-gray-950/95 backdrop-blur">
       <div className="h-full px-4 flex items-center justify-between">
         <div>
-          <p className="text-sm font-semibold text-white">CourseCommons</p>
-          {auth.isLoggedIn && profile && (
+          <p className="text-sm font-semibold text-white">{isInstructorRoute ? 'CourseCommons Instructor' : 'CourseCommons'}</p>
+          {isInstructorRoute ? (
+            instructorAuth.isLoggedIn && (
+              <p className="text-xs text-gray-400">
+                Instructor session active{instructorAuth.email ? ` for ${instructorAuth.email}` : ''}
+              </p>
+            )
+          ) : (
+            auth.isLoggedIn && profile && (
             <p className="text-xs text-gray-400">
               Signed in as {profile.firstName} {profile.lastName}
             </p>
+            )
           )}
         </div>
         <nav className="flex items-center gap-5 text-sm">
-          <Link to="/" className="text-blue-400 hover:text-blue-300">Home</Link>
-          <Link to="/courses" className="text-blue-400 hover:text-blue-300">Courses</Link>
-          <Link to="/community" className="text-blue-400 hover:text-blue-300">Community</Link>
-          <Link to="/channels" className="text-blue-400 hover:text-blue-300">Channels</Link>
-          <Link to="/announcements" className="text-blue-400 hover:text-blue-300">Announcements</Link>
-          {auth.isLoggedIn ? (
-            <button
-              type="button"
-              onClick={handleSignout}
-              className="ml-4 rounded-lg border border-gray-700 px-3 py-1.5 text-sm font-medium text-gray-300 hover:text-white"
-            >
-              Sign out
-            </button>
+          {isInstructorRoute ? (
+            <>
+              {instructorAuth.isLoggedIn ? (
+                <>
+                  <Link to="/instructor/courses" className="text-blue-400 hover:text-blue-300">My Courses</Link>
+                  <Link to="/instructor/courses/new" className="text-blue-400 hover:text-blue-300">Create</Link>
+                </>
+              ) : (
+                <>
+                  <Link to="/" className="text-blue-400 hover:text-blue-300">Home</Link>
+                  <Link to="/courses" className="text-blue-400 hover:text-blue-300">Courses</Link>
+                </>
+              )}
+              {instructorAuth.isLoggedIn ? (
+                <button
+                  type="button"
+                  onClick={handleInstructorSignout}
+                  className="ml-4 rounded-lg border border-gray-700 px-3 py-1.5 text-sm font-medium text-gray-300 hover:text-white"
+                >
+                  Sign out
+                </button>
+              ) : (
+                <>
+                  <Link to="/signup" className="ml-4 rounded-lg bg-blue-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-400">Sign up</Link>
+                  <Link to="/signin" className="rounded-lg border border-gray-700 px-3 py-1.5 text-sm font-medium text-gray-300 hover:text-white">Sign in</Link>
+                </>
+              )}
+            </>
           ) : (
             <>
-              <Link to="/signup" className="ml-4 rounded-lg bg-blue-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-400">Sign up</Link>
-              <Link to="/signin" className="rounded-lg border border-gray-700 px-3 py-1.5 text-sm font-medium text-gray-300 hover:text-white">Sign in</Link>
+              <Link to="/" className="text-blue-400 hover:text-blue-300">Home</Link>
+              <Link to="/courses" className="text-blue-400 hover:text-blue-300">Courses</Link>
+              <Link to="/community" className="text-blue-400 hover:text-blue-300">Community</Link>
+              <Link to="/channels" className="text-blue-400 hover:text-blue-300">Channels</Link>
+              <Link to="/announcements" className="text-blue-400 hover:text-blue-300">Announcements</Link>
+              {auth.isLoggedIn ? (
+                <button
+                  type="button"
+                  onClick={handleLearnerSignout}
+                  className="ml-4 rounded-lg border border-gray-700 px-3 py-1.5 text-sm font-medium text-gray-300 hover:text-white"
+                >
+                  Sign out
+                </button>
+              ) : (
+                <>
+                  <Link to="/signup" className="ml-4 rounded-lg bg-blue-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-400">Sign up</Link>
+                  <Link to="/signin" className="rounded-lg border border-gray-700 px-3 py-1.5 text-sm font-medium text-gray-300 hover:text-white">Sign in</Link>
+                </>
+              )}
             </>
           )}
         </nav>

--- a/client/src/pages/AdminCourses.jsx
+++ b/client/src/pages/AdminCourses.jsx
@@ -1,0 +1,194 @@
+import { useEffect, useState } from 'react'
+import { Link, useLocation } from 'react-router-dom'
+import { deleteAdminCourse, getAdminCourses } from '../services/admin'
+
+function getAdminCoursesErrorMessage(err) {
+  return err.response?.data?.message || 'Unable to load your courses right now.'
+}
+
+function formatPrice(course) {
+  if (course.isFree) {
+    return 'Free'
+  }
+
+  return `$${Number(course.price || 0).toFixed(2)}`
+}
+
+export default function AdminCourses() {
+  const location = useLocation()
+  const [courses, setCourses] = useState([])
+  const [error, setError] = useState('')
+  const [notice, setNotice] = useState(location.state?.notice || '')
+  const [isLoading, setIsLoading] = useState(true)
+  const [deletingId, setDeletingId] = useState('')
+
+  useEffect(() => {
+    let isMounted = true
+
+    async function loadCourses() {
+      try {
+        const adminCourses = await getAdminCourses()
+
+        if (!isMounted) {
+          return
+        }
+
+        setCourses(adminCourses)
+        setError('')
+      } catch (err) {
+        if (!isMounted) {
+          return
+        }
+
+        setError(getAdminCoursesErrorMessage(err))
+      } finally {
+        if (isMounted) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    loadCourses()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  async function handleDelete(courseId) {
+    const confirmed = window.confirm('Delete this course? This action cannot be undone.')
+
+    if (!confirmed) {
+      return
+    }
+
+    setDeletingId(courseId)
+    setError('')
+    setNotice('')
+
+    try {
+      const response = await deleteAdminCourse(courseId)
+      setCourses((prev) => prev.filter((course) => course._id !== courseId))
+      setNotice(response.message || 'Course deleted successfully.')
+    } catch (err) {
+      setError(getAdminCoursesErrorMessage(err))
+    } finally {
+      setDeletingId('')
+    }
+  }
+
+  const freeCourseCount = courses.filter((course) => course.isFree).length
+  const paidCourseCount = courses.length - freeCourseCount
+
+  return (
+    <section className="px-6 py-8 lg:px-10">
+      <div className="mb-8 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <p className="text-sm font-medium uppercase tracking-[0.2em] text-blue-400">Admin workspace</p>
+          <h1 className="mt-2 text-4xl font-bold text-white">Manage your course catalog</h1>
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-gray-300">
+            Create, update, and retire the courses you publish on CourseCommons.
+          </p>
+        </div>
+
+        <Link
+          to="/instructor/courses/new"
+          className="inline-flex rounded-lg bg-blue-500 px-4 py-2.5 text-sm font-semibold text-white hover:bg-blue-400"
+        >
+          Create course
+        </Link>
+      </div>
+
+      {(notice || error) && (
+        <div
+          className={`mb-6 rounded-2xl px-5 py-4 text-sm ${
+            error
+              ? 'border border-red-500/30 bg-red-500/10 text-red-300'
+              : 'border border-emerald-500/30 bg-emerald-500/10 text-emerald-300'
+          }`}
+        >
+          {error || notice}
+        </div>
+      )}
+
+      <div className="mb-8 grid gap-5 md:grid-cols-3">
+        <div className="rounded-2xl border border-gray-800 bg-gray-900/60 p-5">
+          <p className="text-sm text-gray-400">Total courses</p>
+          <p className="mt-3 text-3xl font-semibold text-white">{courses.length}</p>
+        </div>
+        <div className="rounded-2xl border border-gray-800 bg-gray-900/60 p-5">
+          <p className="text-sm text-gray-400">Free courses</p>
+          <p className="mt-3 text-3xl font-semibold text-white">{freeCourseCount}</p>
+        </div>
+        <div className="rounded-2xl border border-gray-800 bg-gray-900/60 p-5">
+          <p className="text-sm text-gray-400">Paid courses</p>
+          <p className="mt-3 text-3xl font-semibold text-white">{paidCourseCount}</p>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="rounded-2xl border border-gray-800 bg-gray-900/60 p-8 text-sm text-gray-300">
+          Loading your admin courses...
+        </div>
+      ) : courses.length === 0 ? (
+        <div className="rounded-2xl border border-gray-800 bg-gray-900/60 p-8">
+          <h2 className="text-2xl font-semibold text-white">No courses published yet</h2>
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-gray-300">
+            Start by creating your first course. You can make it free or paid and edit it later.
+          </p>
+          <Link
+            to="/instructor/courses/new"
+            className="mt-6 inline-flex rounded-lg bg-blue-500 px-4 py-2.5 text-sm font-semibold text-white hover:bg-blue-400"
+          >
+            Create your first course
+          </Link>
+        </div>
+      ) : (
+        <div className="grid gap-6 xl:grid-cols-2">
+          {courses.map((course) => (
+            <article key={course._id} className="overflow-hidden rounded-2xl border border-gray-800 bg-gray-900/60">
+              {course.imageUrl ? (
+                <img src={course.imageUrl} alt={course.title} className="h-52 w-full object-cover" />
+              ) : (
+                <div className="flex h-52 items-center justify-center bg-gray-800 text-sm text-gray-400">
+                  No image available
+                </div>
+              )}
+
+              <div className="space-y-5 p-5">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <h2 className="text-2xl font-semibold text-white">{course.title}</h2>
+                    <p className="mt-2 text-sm text-gray-400">{formatPrice(course)}</p>
+                  </div>
+                  <span className="rounded-full border border-gray-700 px-3 py-1 text-xs uppercase tracking-wide text-gray-300">
+                    {course.isFree ? 'Free' : 'Paid'}
+                  </span>
+                </div>
+
+                <p className="text-sm leading-6 text-gray-300">{course.description}</p>
+
+                <div className="flex flex-wrap gap-3">
+                  <Link
+                    to={`/instructor/courses/${course._id}/edit`}
+                    className="rounded-lg border border-gray-700 px-4 py-2 text-sm font-medium text-gray-200 hover:text-white"
+                  >
+                    Edit course
+                  </Link>
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(course._id)}
+                    disabled={deletingId === course._id}
+                    className="rounded-lg border border-red-500/40 px-4 py-2 text-sm font-medium text-red-300 hover:bg-red-500/10 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {deletingId === course._id ? 'Deleting...' : 'Delete course'}
+                  </button>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/client/src/pages/AdminCreateCourse.jsx
+++ b/client/src/pages/AdminCreateCourse.jsx
@@ -1,0 +1,56 @@
+import { useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import AdminCourseForm from '../components/AdminCourseForm'
+import { createAdminCourse } from '../services/admin'
+
+function getCourseSaveError(err) {
+  return err.response?.data?.message || 'Unable to save this course right now.'
+}
+
+export default function AdminCreateCourse() {
+  const navigate = useNavigate()
+  const [error, setError] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  async function handleSubmit(course) {
+    setError('')
+    setIsSubmitting(true)
+
+    try {
+      const response = await createAdminCourse(course)
+      navigate('/instructor/courses', {
+        replace: true,
+        state: { notice: response.message || 'Course created successfully.' },
+      })
+    } catch (err) {
+      setError(getCourseSaveError(err))
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <section className="px-6 py-8 lg:px-10">
+      <div className="mb-8 space-y-3">
+        <p className="text-sm font-medium uppercase tracking-[0.2em] text-blue-400">Admin workspace</p>
+        <h1 className="text-4xl font-bold text-white">Create a new course</h1>
+        <p className="max-w-2xl text-sm leading-6 text-gray-300">
+          Set up the course metadata, pricing model, and cover image learners will see in the catalog.
+        </p>
+      </div>
+
+      <div className="rounded-2xl border border-gray-800 bg-gray-900/60 p-6">
+        <AdminCourseForm
+          submitLabel="Create course"
+          isSubmitting={isSubmitting}
+          error={error}
+          onSubmit={handleSubmit}
+        />
+      </div>
+
+      <Link to="/instructor/courses" className="mt-6 inline-flex text-sm font-medium text-blue-400 hover:text-blue-300">
+        Back to all courses
+      </Link>
+    </section>
+  )
+}

--- a/client/src/pages/AdminEditCourse.jsx
+++ b/client/src/pages/AdminEditCourse.jsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import AdminCourseForm from '../components/AdminCourseForm'
+import { getAdminCourses, updateAdminCourse } from '../services/admin'
+
+function getCourseSaveError(err) {
+  return err.response?.data?.message || 'Unable to save this course right now.'
+}
+
+export default function AdminEditCourse() {
+  const navigate = useNavigate()
+  const { courseId } = useParams()
+  const [course, setCourse] = useState(null)
+  const [error, setError] = useState('')
+  const [isLoading, setIsLoading] = useState(true)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  useEffect(() => {
+    let isMounted = true
+
+    async function loadCourse() {
+      try {
+        const courses = await getAdminCourses()
+        const matchedCourse = courses.find((item) => item._id === courseId)
+
+        if (!isMounted) {
+          return
+        }
+
+        if (!matchedCourse) {
+          setError('Course not found in your admin catalog.')
+          return
+        }
+
+        setCourse({
+          title: matchedCourse.title,
+          description: matchedCourse.description,
+          imageUrl: matchedCourse.imageUrl,
+          price: String(matchedCourse.price ?? 0),
+          isFree: Boolean(matchedCourse.isFree),
+        })
+      } catch (err) {
+        if (!isMounted) {
+          return
+        }
+
+        setError(getCourseSaveError(err))
+      } finally {
+        if (isMounted) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    loadCourse()
+
+    return () => {
+      isMounted = false
+    }
+  }, [courseId])
+
+  async function handleSubmit(updatedCourse) {
+    setError('')
+    setIsSubmitting(true)
+
+    try {
+      const response = await updateAdminCourse(courseId, updatedCourse)
+      navigate('/instructor/courses', {
+        replace: true,
+        state: { notice: response.message || 'Course updated successfully.' },
+      })
+    } catch (err) {
+      setError(getCourseSaveError(err))
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <section className="px-6 py-8 lg:px-10">
+      <div className="mb-8 space-y-3">
+        <p className="text-sm font-medium uppercase tracking-[0.2em] text-blue-400">Admin workspace</p>
+        <h1 className="text-4xl font-bold text-white">Edit course</h1>
+        <p className="max-w-2xl text-sm leading-6 text-gray-300">
+          Update course details and pricing without leaving the admin workspace.
+        </p>
+      </div>
+
+      <div className="rounded-2xl border border-gray-800 bg-gray-900/60 p-6">
+        {isLoading ? (
+          <p className="text-sm text-gray-300">Loading course details...</p>
+        ) : course ? (
+          <AdminCourseForm
+            initialValues={course}
+            submitLabel="Save changes"
+            isSubmitting={isSubmitting}
+            error={error}
+            onSubmit={handleSubmit}
+          />
+        ) : (
+          <p className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+            {error || 'Course not found.'}
+          </p>
+        )}
+      </div>
+
+      <Link to="/instructor/courses" className="mt-6 inline-flex text-sm font-medium text-blue-400 hover:text-blue-300">
+        Back to all courses
+      </Link>
+    </section>
+  )
+}

--- a/client/src/pages/AdminSignin.jsx
+++ b/client/src/pages/AdminSignin.jsx
@@ -1,0 +1,108 @@
+import { useState } from 'react'
+import { Link, Navigate, useLocation, useNavigate } from 'react-router-dom'
+import { useAtomValue, useSetAtom } from 'jotai'
+import { adminSignin } from '../services/admin'
+import { adminAuthAtom } from '../state/adminAuthAtom'
+
+export default function AdminSignin() {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const adminAuth = useAtomValue(adminAuthAtom)
+  const setAdminAuth = useSetAtom(adminAuthAtom)
+  const [form, setForm] = useState({ email: '', password: '' })
+  const [error, setError] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+
+  if (adminAuth.isLoggedIn) {
+    return <Navigate to="/admin/courses" replace />
+  }
+
+  function handleChange(event) {
+    setForm((prev) => ({ ...prev, [event.target.name]: event.target.value }))
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault()
+    setError('')
+    setIsLoading(true)
+
+    try {
+      const data = await adminSignin(form)
+      localStorage.setItem('adminToken', data.token)
+      localStorage.setItem('adminEmail', form.email)
+      setAdminAuth({ token: data.token, email: form.email, isLoggedIn: true })
+
+      const destination = location.state?.from || '/admin/courses'
+      navigate(destination, { replace: true })
+    } catch (err) {
+      setError(err.response?.data?.message || 'Admin sign in failed. Please try again.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-full items-center justify-center px-6 py-16">
+      <div className="w-full max-w-md space-y-8">
+        <div className="text-center">
+          <p className="text-sm font-medium uppercase tracking-[0.2em] text-blue-400">Admin access</p>
+          <h1 className="mt-3 text-3xl font-bold text-white">Sign in to manage your courses</h1>
+          <p className="mt-2 text-sm text-gray-400">
+            Need an admin account?{' '}
+            <Link to="/admin/signup" className="text-blue-400 hover:text-blue-300">
+              Create one
+            </Link>
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div>
+            <label htmlFor="email" className="mb-1.5 block text-sm font-medium text-gray-300">
+              Email address
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              required
+              value={form.email}
+              onChange={handleChange}
+              className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2.5 text-sm text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+              placeholder="teacher@example.com"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="password" className="mb-1.5 block text-sm font-medium text-gray-300">
+              Password
+            </label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              required
+              value={form.password}
+              onChange={handleChange}
+              className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2.5 text-sm text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+              placeholder="Your password"
+            />
+          </div>
+
+          {error && (
+            <p className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+              {error}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="w-full rounded-lg bg-blue-500 px-4 py-2.5 text-sm font-semibold text-white hover:bg-blue-400 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isLoading ? 'Signing in...' : 'Sign in as admin'}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/client/src/pages/AdminSignup.jsx
+++ b/client/src/pages/AdminSignup.jsx
@@ -1,0 +1,153 @@
+import { useState } from 'react'
+import { Link, Navigate, useNavigate } from 'react-router-dom'
+import { useAtomValue } from 'jotai'
+import { adminSignup } from '../services/admin'
+import { adminAuthAtom } from '../state/adminAuthAtom'
+import { authAtom } from '../state/authAtom'
+
+export default function AdminSignup() {
+  const navigate = useNavigate()
+  const instructorAuth = useAtomValue(adminAuthAtom)
+  const learnerAuth = useAtomValue(authAtom)
+  const [form, setForm] = useState({ firstName: '', lastName: '', email: '', password: '' })
+  const [error, setError] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+
+  if (instructorAuth.isLoggedIn) {
+    return <Navigate to="/instructor/courses" replace />
+  }
+
+  if (learnerAuth.isLoggedIn) {
+    return <Navigate to="/" replace />
+  }
+
+  function handleChange(event) {
+    setForm((prev) => ({ ...prev, [event.target.name]: event.target.value }))
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault()
+    setError('')
+    setIsLoading(true)
+
+    try {
+      await adminSignup(form)
+      navigate('/signin', {
+        replace: true,
+        state: { notice: 'Instructor account created. Sign in to manage your courses.' },
+      })
+    } catch (err) {
+      setError(err.response?.data?.message || 'Instructor signup failed. Please try again.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-full items-center justify-center px-6 py-16">
+      <div className="w-full max-w-md space-y-8">
+        <div className="text-center">
+          <p className="text-sm font-medium uppercase tracking-[0.2em] text-blue-400">Instructor account</p>
+          <h1 className="mt-3 text-3xl font-bold text-white">Create your instructor account</h1>
+          <p className="mt-2 text-sm text-gray-400">
+            Want to learn instead?{' '}
+            <Link to="/signup/learner" className="text-blue-400 hover:text-blue-300">
+              Sign up as a learner
+            </Link>
+          </p>
+          <p className="mt-1 text-sm text-gray-400">
+            Already have an account?{' '}
+            <Link to="/signin" className="text-blue-400 hover:text-blue-300">
+              Sign in
+            </Link>
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="firstName" className="mb-1.5 block text-sm font-medium text-gray-300">
+                First name
+              </label>
+              <input
+                id="firstName"
+                name="firstName"
+                type="text"
+                required
+                minLength={2}
+                value={form.firstName}
+                onChange={handleChange}
+                className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2.5 text-sm text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+                placeholder="Jane"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="lastName" className="mb-1.5 block text-sm font-medium text-gray-300">
+                Last name
+              </label>
+              <input
+                id="lastName"
+                name="lastName"
+                type="text"
+                required
+                minLength={2}
+                value={form.lastName}
+                onChange={handleChange}
+                className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2.5 text-sm text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+                placeholder="Teacher"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label htmlFor="email" className="mb-1.5 block text-sm font-medium text-gray-300">
+              Email address
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              required
+              value={form.email}
+              onChange={handleChange}
+              className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2.5 text-sm text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+              placeholder="teacher@example.com"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="password" className="mb-1.5 block text-sm font-medium text-gray-300">
+              Password
+            </label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              required
+              minLength={6}
+              value={form.password}
+              onChange={handleChange}
+              className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2.5 text-sm text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+              placeholder="At least 6 characters"
+            />
+          </div>
+
+          {error && (
+            <p className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+              {error}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="w-full rounded-lg bg-blue-500 px-4 py-2.5 text-sm font-semibold text-white hover:bg-blue-400 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isLoading ? 'Creating account...' : 'Create instructor account'}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/client/src/pages/LearnerSignup.jsx
+++ b/client/src/pages/LearnerSignup.jsx
@@ -1,0 +1,147 @@
+import { useState } from 'react'
+import { useNavigate, Link, Navigate } from 'react-router-dom'
+import { useAtomValue } from 'jotai'
+import { signup } from '../services/auth'
+import { adminAuthAtom } from '../state/adminAuthAtom'
+import { authAtom } from '../state/authAtom'
+
+export default function LearnerSignup() {
+  const navigate = useNavigate()
+  const learnerAuth = useAtomValue(authAtom)
+  const instructorAuth = useAtomValue(adminAuthAtom)
+  const [form, setForm] = useState({ firstName: '', lastName: '', email: '', password: '' })
+  const [error, setError] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+
+  if (learnerAuth.isLoggedIn) {
+    return <Navigate to="/" replace />
+  }
+
+  if (instructorAuth.isLoggedIn) {
+    return <Navigate to="/instructor/courses" replace />
+  }
+
+  function handleChange(event) {
+    setForm((prev) => ({ ...prev, [event.target.name]: event.target.value }))
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault()
+    setError('')
+    setIsLoading(true)
+
+    try {
+      await signup(form)
+      navigate('/signin', {
+        replace: true,
+        state: { notice: 'Learner account created. Sign in to continue.' },
+      })
+    } catch (err) {
+      setError(err.response?.data?.message || 'Signup failed. Please try again.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-full items-center justify-center px-6 py-16">
+      <div className="w-full max-w-md space-y-8">
+        <div className="text-center">
+          <p className="text-sm font-medium uppercase tracking-[0.2em] text-blue-400">Learner account</p>
+          <h1 className="mt-3 text-3xl font-bold text-white">Create your learner account</h1>
+          <p className="mt-2 text-sm text-gray-400">
+            Want to teach instead?{' '}
+            <Link to="/signup/instructor" className="text-blue-400 hover:text-blue-300">
+              Sign up as an instructor
+            </Link>
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="firstName" className="block text-sm font-medium text-gray-300 mb-1.5">
+                First name
+              </label>
+              <input
+                id="firstName"
+                name="firstName"
+                type="text"
+                required
+                minLength={2}
+                value={form.firstName}
+                onChange={handleChange}
+                className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2.5 text-sm text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+                placeholder="John"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="lastName" className="block text-sm font-medium text-gray-300 mb-1.5">
+                Last name
+              </label>
+              <input
+                id="lastName"
+                name="lastName"
+                type="text"
+                required
+                minLength={2}
+                value={form.lastName}
+                onChange={handleChange}
+                className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2.5 text-sm text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+                placeholder="Doe"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-gray-300 mb-1.5">
+              Email address
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              required
+              value={form.email}
+              onChange={handleChange}
+              className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2.5 text-sm text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+              placeholder="john@example.com"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-gray-300 mb-1.5">
+              Password
+            </label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              required
+              minLength={6}
+              value={form.password}
+              onChange={handleChange}
+              className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2.5 text-sm text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+              placeholder="At least 6 characters"
+            />
+          </div>
+
+          {error && (
+            <p className="rounded-lg bg-red-500/10 border border-red-500/30 px-4 py-3 text-sm text-red-300">
+              {error}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="w-full rounded-lg bg-blue-500 px-4 py-2.5 text-sm font-semibold text-white hover:bg-blue-400 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isLoading ? 'Creating account...' : 'Create learner account'}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/client/src/pages/Signin.jsx
+++ b/client/src/pages/Signin.jsx
@@ -1,19 +1,50 @@
 import { useState } from 'react'
-import { useNavigate, Link } from 'react-router-dom'
-import { useSetAtom } from 'jotai'
+import { useNavigate, Link, Navigate, useLocation } from 'react-router-dom'
+import { useAtomValue, useSetAtom } from 'jotai'
+import { adminSignin } from '../services/admin'
 import { getProfile, signin } from '../services/auth'
+import { adminAuthAtom } from '../state/adminAuthAtom'
 import { authAtom } from '../state/authAtom'
 import { profileAtom } from '../state/profileAtom'
 import { enrolledCoursesAtom } from '../state/enrolledCoursesAtom'
+import { clearAdminSession, clearLearnerSession } from '../state/sessionActions'
+
+function getSigninErrorMessage(userError, instructorError) {
+  const instructorMessage = instructorError?.response?.data?.message
+  const userMessage = userError?.response?.data?.message
+
+  if (instructorMessage === 'Invalid password' || userMessage === 'Invalid password') {
+    return 'Invalid password'
+  }
+
+  if (instructorMessage === 'Admin not found' && userMessage === 'User not found') {
+    return 'No account found for this email'
+  }
+
+  return userMessage || instructorMessage || 'Sign in failed. Please try again.'
+}
 
 export default function Signin() {
   const navigate = useNavigate()
+  const location = useLocation()
+  const learnerAuth = useAtomValue(authAtom)
+  const instructorAuth = useAtomValue(adminAuthAtom)
   const setAuth = useSetAtom(authAtom)
+  const setInstructorAuth = useSetAtom(adminAuthAtom)
   const setProfile = useSetAtom(profileAtom)
   const setEnrolledCourses = useSetAtom(enrolledCoursesAtom)
   const [form, setForm] = useState({ email: '', password: '' })
+  const [notice] = useState(location.state?.notice || '')
   const [error, setError] = useState('')
   const [isLoading, setIsLoading] = useState(false)
+
+  if (instructorAuth.isLoggedIn) {
+    return <Navigate to="/instructor/courses" replace />
+  }
+
+  if (learnerAuth.isLoggedIn) {
+    return <Navigate to="/" replace />
+  }
 
   function handleChange(e) {
     setForm((prev) => ({ ...prev, [e.target.name]: e.target.value }))
@@ -23,17 +54,27 @@ export default function Signin() {
     e.preventDefault()
     setError('')
     setIsLoading(true)
+    clearLearnerSession()
+    clearAdminSession()
+    setEnrolledCourses([])
 
     try {
-      const data = await signin(form)
-      localStorage.setItem('token', data.token)
-      setAuth({ token: data.token, isLoggedIn: true })
-      setEnrolledCourses([])
-      const user = await getProfile()
-      setProfile(user)
-      navigate('/')
-    } catch (err) {
-      setError(err.response?.data?.message || 'Sign in failed. Please try again.')
+      const instructorData = await adminSignin(form)
+      localStorage.setItem('adminToken', instructorData.token)
+      localStorage.setItem('adminEmail', form.email)
+      setInstructorAuth({ token: instructorData.token, email: form.email, isLoggedIn: true })
+      navigate('/instructor/courses', { replace: true })
+    } catch (instructorError) {
+      try {
+        const data = await signin(form)
+        localStorage.setItem('token', data.token)
+        setAuth({ token: data.token, isLoggedIn: true })
+        const user = await getProfile()
+        setProfile(user)
+        navigate('/', { replace: true })
+      } catch (userError) {
+        setError(getSigninErrorMessage(userError, instructorError))
+      }
     } finally {
       setIsLoading(false)
     }
@@ -45,12 +86,21 @@ export default function Signin() {
         <div className="text-center">
           <h1 className="text-3xl font-bold text-white">Sign in to your account</h1>
           <p className="mt-2 text-sm text-gray-400">
-            Don't have an account?{' '}
+            We will route you to the right dashboard automatically.
+          </p>
+          <p className="mt-2 text-sm text-gray-400">
+            Don't have an account yet?{' '}
             <Link to="/signup" className="text-blue-400 hover:text-blue-300">
               Sign up
             </Link>
           </p>
         </div>
+
+        {notice && (
+          <p className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-300">
+            {notice}
+          </p>
+        )}
 
         <form onSubmit={handleSubmit} className="space-y-5">
           <div>
@@ -96,7 +146,7 @@ export default function Signin() {
             disabled={isLoading}
             className="w-full rounded-lg bg-blue-500 px-4 py-2.5 text-sm font-semibold text-white hover:bg-blue-400 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {isLoading ? 'Signing in...' : 'Sign in'}
+            {isLoading ? 'Signing in...' : 'Continue'}
           </button>
         </form>
       </div>

--- a/client/src/pages/Signup.jsx
+++ b/client/src/pages/Signup.jsx
@@ -1,37 +1,26 @@
-import { useState } from 'react'
-import { useNavigate, Link } from 'react-router-dom'
-import { signup } from '../services/auth'
+import { Link, Navigate } from 'react-router-dom'
+import { useAtomValue } from 'jotai'
+import { adminAuthAtom } from '../state/adminAuthAtom'
+import { authAtom } from '../state/authAtom'
 
 export default function Signup() {
-  const navigate = useNavigate()
-  const [form, setForm] = useState({ firstName: '', lastName: '', email: '', password: '' })
-  const [error, setError] = useState('')
-  const [isLoading, setIsLoading] = useState(false)
+  const learnerAuth = useAtomValue(authAtom)
+  const instructorAuth = useAtomValue(adminAuthAtom)
 
-  function handleChange(e) {
-    setForm((prev) => ({ ...prev, [e.target.name]: e.target.value }))
+  if (learnerAuth.isLoggedIn) {
+    return <Navigate to="/" replace />
   }
 
-  async function handleSubmit(e) {
-    e.preventDefault()
-    setError('')
-    setIsLoading(true)
-
-    try {
-      await signup(form)
-      navigate('/signin')
-    } catch (err) {
-      setError(err.response?.data?.message || 'Signup failed. Please try again.')
-    } finally {
-      setIsLoading(false)
-    }
+  if (instructorAuth.isLoggedIn) {
+    return <Navigate to="/instructor/courses" replace />
   }
 
   return (
     <div className="flex min-h-full items-center justify-center px-6 py-16">
-      <div className="w-full max-w-md space-y-8">
+      <div className="w-full max-w-4xl space-y-10">
         <div className="text-center">
-          <h1 className="text-3xl font-bold text-white">Create your account</h1>
+          <p className="text-sm font-medium uppercase tracking-[0.2em] text-blue-400">Choose account type</p>
+          <h1 className="mt-3 text-4xl font-bold text-white">Sign up as a learner or instructor</h1>
           <p className="mt-2 text-sm text-gray-400">
             Already have an account?{' '}
             <Link to="/signin" className="text-blue-400 hover:text-blue-300">
@@ -40,90 +29,31 @@ export default function Signup() {
           </p>
         </div>
 
-        <form onSubmit={handleSubmit} className="space-y-5">
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label htmlFor="firstName" className="block text-sm font-medium text-gray-300 mb-1.5">
-                First name
-              </label>
-              <input
-                id="firstName"
-                name="firstName"
-                type="text"
-                required
-                minLength={2}
-                value={form.firstName}
-                onChange={handleChange}
-                className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2.5 text-sm text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
-                placeholder="John"
-              />
-            </div>
-
-            <div>
-              <label htmlFor="lastName" className="block text-sm font-medium text-gray-300 mb-1.5">
-                Last name
-              </label>
-              <input
-                id="lastName"
-                name="lastName"
-                type="text"
-                required
-                minLength={2}
-                value={form.lastName}
-                onChange={handleChange}
-                className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2.5 text-sm text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
-                placeholder="Doe"
-              />
-            </div>
-          </div>
-
-          <div>
-            <label htmlFor="email" className="block text-sm font-medium text-gray-300 mb-1.5">
-              Email address
-            </label>
-            <input
-              id="email"
-              name="email"
-              type="email"
-              required
-              value={form.email}
-              onChange={handleChange}
-              className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2.5 text-sm text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
-              placeholder="john@example.com"
-            />
-          </div>
-
-          <div>
-            <label htmlFor="password" className="block text-sm font-medium text-gray-300 mb-1.5">
-              Password
-            </label>
-            <input
-              id="password"
-              name="password"
-              type="password"
-              required
-              minLength={6}
-              value={form.password}
-              onChange={handleChange}
-              className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2.5 text-sm text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
-              placeholder="At least 6 characters"
-            />
-          </div>
-
-          {error && (
-            <p className="rounded-lg bg-red-500/10 border border-red-500/30 px-4 py-3 text-sm text-red-300">
-              {error}
-            </p>
-          )}
-
-          <button
-            type="submit"
-            disabled={isLoading}
-            className="w-full rounded-lg bg-blue-500 px-4 py-2.5 text-sm font-semibold text-white hover:bg-blue-400 disabled:opacity-50 disabled:cursor-not-allowed"
+        <div className="grid gap-6 md:grid-cols-2">
+          <Link
+            to="/signup/learner"
+            className="rounded-3xl border border-gray-800 bg-gray-900/60 p-8 transition hover:border-blue-500/60 hover:bg-gray-900"
           >
-            {isLoading ? 'Creating account...' : 'Create account'}
-          </button>
-        </form>
+            <p className="text-sm font-medium uppercase tracking-[0.2em] text-blue-400">Learner</p>
+            <h2 className="mt-4 text-2xl font-semibold text-white">Join to enroll and keep learning</h2>
+            <p className="mt-3 text-sm leading-6 text-gray-300">
+              Create a learner account to browse courses, enroll, and track your learning dashboard.
+            </p>
+            <span className="mt-6 inline-flex text-sm font-semibold text-blue-300">Continue as learner</span>
+          </Link>
+
+          <Link
+            to="/signup/instructor"
+            className="rounded-3xl border border-gray-800 bg-gray-900/60 p-8 transition hover:border-blue-500/60 hover:bg-gray-900"
+          >
+            <p className="text-sm font-medium uppercase tracking-[0.2em] text-blue-400">Instructor</p>
+            <h2 className="mt-4 text-2xl font-semibold text-white">Create and manage your own courses</h2>
+            <p className="mt-3 text-sm leading-6 text-gray-300">
+              Set up an instructor account to publish, edit, and manage your course catalog.
+            </p>
+            <span className="mt-6 inline-flex text-sm font-semibold text-blue-300">Continue as instructor</span>
+          </Link>
+        </div>
       </div>
     </div>
   )

--- a/client/src/services/admin.js
+++ b/client/src/services/admin.js
@@ -1,0 +1,31 @@
+import adminApi from './adminApi'
+
+export async function adminSignup({ email, password, firstName, lastName }) {
+  const response = await adminApi.post('/admin/signup', { email, password, firstName, lastName })
+  return response.data
+}
+
+export async function adminSignin({ email, password }) {
+  const response = await adminApi.post('/admin/signin', { email, password })
+  return response.data
+}
+
+export async function getAdminCourses() {
+  const response = await adminApi.get('/admin/course/bulk')
+  return response.data.courses ?? []
+}
+
+export async function createAdminCourse(course) {
+  const response = await adminApi.post('/admin/course/create', course)
+  return response.data
+}
+
+export async function updateAdminCourse(courseId, course) {
+  const response = await adminApi.put(`/admin/course/update/${courseId}`, course)
+  return response.data
+}
+
+export async function deleteAdminCourse(courseId) {
+  const response = await adminApi.delete(`/admin/course/delete/${courseId}`)
+  return response.data
+}

--- a/client/src/services/adminApi.js
+++ b/client/src/services/adminApi.js
@@ -1,0 +1,40 @@
+import axios from 'axios'
+import { clearAdminSession } from '../state/sessionActions'
+
+const adminApi = axios.create({
+  baseURL: import.meta.env.VITE_API_URL,
+})
+
+adminApi.interceptors.request.use((config) => {
+  const token = localStorage.getItem('adminToken')
+
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`
+  }
+
+  return config
+})
+
+adminApi.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    const status = error.response?.status
+    const hasAuthHeader = Boolean(error.config?.headers?.Authorization)
+
+    if (hasAuthHeader && (status === 401 || status === 403)) {
+      clearAdminSession()
+
+      if (typeof window !== 'undefined') {
+        const currentPath = window.location.pathname
+
+        if (currentPath !== '/signin' && currentPath !== '/signup' && currentPath !== '/signup/instructor') {
+          window.location.assign('/signin')
+        }
+      }
+    }
+
+    return Promise.reject(error)
+  },
+)
+
+export default adminApi

--- a/client/src/state/adminAuthAtom.js
+++ b/client/src/state/adminAuthAtom.js
@@ -1,0 +1,7 @@
+import { atom } from 'jotai'
+
+export const adminAuthAtom = atom({
+  token: localStorage.getItem('adminToken') ?? null,
+  email: localStorage.getItem('adminEmail') ?? '',
+  isLoggedIn: Boolean(localStorage.getItem('adminToken')),
+})

--- a/client/src/state/sessionActions.js
+++ b/client/src/state/sessionActions.js
@@ -1,4 +1,5 @@
 import { appStore } from './store'
+import { adminAuthAtom } from './adminAuthAtom'
 import { authAtom } from './authAtom'
 import { enrolledCoursesAtom } from './enrolledCoursesAtom'
 import { profileAtom } from './profileAtom'
@@ -8,4 +9,10 @@ export function clearLearnerSession() {
   appStore.set(authAtom, { token: null, isLoggedIn: false })
   appStore.set(profileAtom, null)
   appStore.set(enrolledCoursesAtom, [])
+}
+
+export function clearAdminSession() {
+  localStorage.removeItem('adminToken')
+  localStorage.removeItem('adminEmail')
+  appStore.set(adminAuthAtom, { token: null, email: '', isLoggedIn: false })
 }

--- a/middleware/adminAuth.js
+++ b/middleware/adminAuth.js
@@ -4,13 +4,17 @@ const ADMIN_JWT_SECRET = process.env.ADMIN_JWT_SECRET;
 
 function adminAuth(req, res, next){
 
-    const token = req.headers.authorization;
+    const authHeader = req.headers.authorization;
 
-    if(!token){
+    if(!authHeader){
         return res.status(401).json({
             message: "Token missing"
         });
     }
+
+    const token = authHeader.startsWith("Bearer ")
+        ? authHeader.slice(7)
+        : authHeader;
 
     try{
 


### PR DESCRIPTION
- Learner and instructor experiences are now separated cleanly.
- Shared sign-in auto-routes by role.
- Sign-up asks account type first, then routes to learner or instructor sign-up.
- Instructor nav is instructor-only.
- Backend instructor auth now correctly supports Bearer tokens via adminAuth.js.

closes #50 